### PR TITLE
Exclude model's created/updated timestamps from json responses

### DIFF
--- a/app/Http/Controllers/WineApiController.php
+++ b/app/Http/Controllers/WineApiController.php
@@ -37,7 +37,7 @@ class WineApiController extends BaseController {
 			'competition_id' => $competitionId,
 		]));
 
-		return response()->json($wines);
+		return $wines;
 	}
 
 	public function update(Wine $wines, Request $request) {

--- a/app/MasterData/Applicant.php
+++ b/app/MasterData/Applicant.php
@@ -77,6 +77,16 @@ class Applicant extends Model implements AdministrateModel {
 	];
 
 	/**
+	 * The attributes that should be hidden for arrays/json.
+	 *
+	 * @var array
+	 */
+	protected $hidden = [
+		'created_at',
+		'updated_at',
+	];
+
+	/**
 	 * primary key must not be incremented
 	 * 
 	 * @var boolean

--- a/app/MasterData/Association.php
+++ b/app/MasterData/Association.php
@@ -53,6 +53,16 @@ class Association extends Model implements AdministrateModel {
 	];
 
 	/**
+	 * The attributes that should be hidden for arrays/json.
+	 *
+	 * @var array
+	 */
+	protected $hidden = [
+		'created_at',
+		'updated_at',
+	];
+
+	/**
 	 * Check if the given user is authorized to administrate
 	 * 
 	 * @param User $user

--- a/app/MasterData/WineSort.php
+++ b/app/MasterData/WineSort.php
@@ -53,6 +53,16 @@ class WineSort extends Model {
 	];
 
 	/**
+	 * The attributes that should be hidden for arrays/json.
+	 *
+	 * @var array
+	 */
+	protected $hidden = [
+		'created_at',
+		'updated_at',
+	];
+
+	/**
 	 * 
 	 * @return string
 	 */

--- a/app/Wine.php
+++ b/app/Wine.php
@@ -88,6 +88,16 @@ class Wine extends Model implements AdministrateModel {
 	];
 
 	/**
+	 * The attributes that should be hidden for arrays/json.
+	 *
+	 * @var array
+	 */
+	protected $hidden = [
+		'created_at',
+		'updated_at',
+	];
+
+	/**
 	 * Get next possible id for insert
 	 * 
 	 * @param Competition $competition


### PR DESCRIPTION
As measured and profiled with blackfire.io, the serialization of
timestamps (e.g. created_at, updated_at) of models can be a bottle
neck. In fact, almost 50% of the computation power can be saved
by hiding those timestamps that are not used on the client anyway.

![bildschirmfoto von 2017-02-23 10-26-22](https://cloud.githubusercontent.com/assets/1374172/23253754/f6a1c76c-f9b5-11e6-95d8-d69f3547f6db.png)
![bildschirmfoto von 2017-02-23 10-36-53](https://cloud.githubusercontent.com/assets/1374172/23253753/f67c1f8a-f9b5-11e6-9a80-f063884b65c5.png)

