### PR TITLE
Fix unassignment of tasting session admins

### DIFF
--- a/app/Http/Controllers/TastingSessionController.php
+++ b/app/Http/Controllers/TastingSessionController.php
@@ -246,10 +246,6 @@ class TastingSessionController extends BaseController {
 		$this->checkTastingSessionLocked($tastingSession);
 
 		$data = Input::all();
-		//unset user if set to 'none'
-		if (isset($data['wuser_username']) && $data['wuser_username'] === 'none') {
-			unset($data['wuser_username']);
-		}
 		try {
 			$this->tastingHandler->updateTastingSession($tastingSession, $data);
 		} catch (ValidationException $ve) {

--- a/app/Tasting/Handler.php
+++ b/app/Tasting/Handler.php
@@ -291,6 +291,9 @@ class Handler implements TastingHandler {
 	}
 
 	public function updateTastingSession(TastingSession $tastingSession, array $data) {
+		if (isset($data['wuser_username']) && $data['wuser_username'] === 'none') {
+			$data['wuser_username'] = null;
+		}
 		$validator = new TastingSessionValidator($data, $tastingSession);
 		$validator->setCompetition($tastingSession->competition);
 		$validator->validateUpdate();


### PR DESCRIPTION
Instead of unsetting the parameter, it has to be set to null to properly
propagate the change to the database.

Fixes https://tree.taiga.io/project/christophwurst-weinstein/issue/3