### PR TITLE
Fix saving emtpy comments

### DIFF
--- a/app/Database/Repositories/WineRepository.php
+++ b/app/Database/Repositories/WineRepository.php
@@ -45,7 +45,7 @@ class WineRepository {
 	 * @return Wine
 	 */
 	public function addComment(Wine $wine, string $comment): Wine {
-		$wine->comment = $comment;
+		$wine->comment = empty($comment) ? null : $comment;
 		$wine->save();
 		return $wine;
 	}

--- a/app/Tasting/Handler.php
+++ b/app/Tasting/Handler.php
@@ -381,7 +381,7 @@ class Handler implements TastingHandler {
 			 * Store comment
 			 */
 			$commentKey = 'comment-' . $commission->side;
-			$comment = isset($data[$commentKey]) ? $data[$commentKey] : null;
+			$comment = isset($data[$commentKey]) && !empty($data[$commentKey]) ? $data[$commentKey] : null;
 			$this->wineRepository->addComment($tastingNumber->wine, $comment);
 		}
 	}
@@ -414,7 +414,7 @@ class Handler implements TastingHandler {
 		 * Store comment
 		 */
 		$wine = $tastingNumber->wine;
-		$wine->comment = isset($data['comment']) ? $data['comment'] : null;
+		$wine->comment = isset($data['comment']) && !empty($data['comment']) ? $data['comment'] : null;
 		$wine->save();
 		DB::commit();
 	}

--- a/app/Tasting/Handler.php
+++ b/app/Tasting/Handler.php
@@ -381,7 +381,7 @@ class Handler implements TastingHandler {
 			 * Store comment
 			 */
 			$commentKey = 'comment-' . $commission->side;
-			$comment = isset($data[$commentKey]) && !empty($data[$commentKey]) ? $data[$commentKey] : null;
+			$comment = isset($data[$commentKey]) ? $data[$commentKey] : '';
 			$this->wineRepository->addComment($tastingNumber->wine, $comment);
 		}
 	}

--- a/tests/Integration/Competition/TastingTest.php
+++ b/tests/Integration/Competition/TastingTest.php
@@ -186,7 +186,7 @@ class TastingTest extends TestCase {
 		$this->dontSee('1. Verkostung abschließen');
 		$this->seeInDatabase('wine', [
 			'id' => $tastingNumber2->wine->id,
-			'comment' => '',
+			'comment' => null,
 		]);
 
 		// Still one tasting number left …
@@ -205,7 +205,7 @@ class TastingTest extends TestCase {
 		$this->see('1. Verkostung abschließen');
 		$this->seeInDatabase('wine', [
 			'id' => $tastingNumber3->wine->id,
-			'comment' => '',
+			'comment' => null,
 		]);
 
 		// Let's take a look at the statistics …


### PR DESCRIPTION
Empty comments should result in a NULL value in the DB because
when exporting flaws we want to be able to filter accordingly.