### PR TITLE
Make `chosen` mandatory for `kdb`, `sosi`; disallow for `ex`

### DIFF
--- a/app/Contracts/WineHandler.php
+++ b/app/Contracts/WineHandler.php
@@ -76,12 +76,6 @@ interface WineHandler {
 	public function importSosi(UploadedFile $file, Competition $competition);
 
 	/**
-	 * @param Wine $wine
-	 * @param array $data
-	 */
-	public function updateChosen(Wine $wine, array $data);
-
-	/**
 	 * @param UploadedFile $file
 	 * @param Competition $competition
 	 * @return int Number of read lines

--- a/app/Http/Controllers/WineApiController.php
+++ b/app/Http/Controllers/WineApiController.php
@@ -7,6 +7,7 @@ use App\Exceptions\InvalidCompetitionStateException;
 use App\Exceptions\ValidationException;
 use App\MasterData\Competition;
 use App\Wine;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
@@ -58,6 +59,8 @@ class WineApiController extends BaseController {
 			return $this->wineHandler->update($wines, $data);
 		} catch (ValidationException $ex) {
 			return response()->json(['errors' => $ex->getErrors()], 412);
+		} catch (AuthorizationException $ex) {
+			return response()->json(['error' => "Änderung nicht erlaubt"], 400);
 		} catch (InvalidCompetitionStateException $ex) {
 			return response()->json(['error' => "Diese Änderung ist in diesem Abschnitt der Verkostung nicht erlaubt."], 400);
 		}

--- a/app/Http/Controllers/WineController.php
+++ b/app/Http/Controllers/WineController.php
@@ -527,26 +527,6 @@ class WineController extends BaseController {
 	}
 
 	/**
-	 * 
-	 * @param Wine $wine
-	 */
-	public function updateChosen(Wine $wine) {
-		$this->authorize('update-wine', $wine);
-
-		try {
-			$this->wineHandler->updateChosen($wine, Input::only('value'));
-		} catch (ValidationException $ve) {
-			return Response::json([
-					'error' => 'Fehler beim setzen von SoSi',
-					'wines' => Wine::chosen()->pluck('id')->all(),
-			]);
-		}
-		return Response::json([
-				'wines' => Wine::chosen()->pluck('id')->all(),
-		]);
-	}
-
-	/**
 	 * Show import form
 	 * 
 	 * @param Competition $competition

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -274,10 +274,6 @@ Route::group(array('middleware' => 'auth'), function() {
 			'as' => 'enrollment.wines/update-sosi',
 			'uses' => 'WineController@updateSosi',
 		));
-		Route::post('update-chosen', array(
-			'as' => 'enrollment.wines/update-chosen',
-			'uses' => 'WineController@updateChosen',
-		));
 	});
 
 	/*

--- a/resources/views/competition/wines/import-chosen.blade.php
+++ b/resources/views/competition/wines/import-chosen.blade.php
@@ -5,7 +5,8 @@
 <p>
     Hier kann eine Excel-Datei mit allen Dateinummern hochgeladen werden, die ausgeschenkt
     werden sollen. Alle Weine, die nicht in dieser hochgeladenen Datei enthalten sind,
-    werden nicht zum Ausschank ausgewählt!
+    werden nicht zum Ausschank ausgewählt!<br>
+    <i>KdB</i> und <i>SoSi</i> werden immer ausgeschenkt. <i>Ex</i>-Weine dürfen nicht ausgeschenkt werden.
 </p>
 <div class="alert alert-info" role="alert">
     <button type="button" class="close" data-dismiss="alert">

--- a/tests/Unit/Wine/HandlerTest.php
+++ b/tests/Unit/Wine/HandlerTest.php
@@ -95,7 +95,7 @@ class HandlerTest extends TestCase {
 			->once()
 			->andReturn(true);
 		$competitionState->shouldReceive('is')
-			->never()
+			->times(2)
 			->andReturn(false);
 		$wine->shouldReceive('fill')
 			->with($data);
@@ -447,6 +447,10 @@ class HandlerTest extends TestCase {
 		$competition->shouldReceive('getAttribute')
 			->with('competitionState')
 			->andReturn($competitionState);
+		$competitionState->shouldReceive('is')
+			->times(2)
+			->with(CompetitionState::STATE_CHOOSE)
+			->andReturn(false);
 		$wine->shouldReceive('fill')
 			->with($data);
 		$wine->shouldReceive('isDirty')

--- a/tests/Unit/Wine/HandlerTest.php
+++ b/tests/Unit/Wine/HandlerTest.php
@@ -531,33 +531,6 @@ class HandlerTest extends TestCase {
 		// TODO
 	}
 
-	public function testUpdateChosen() {
-		$wine = Mockery::mock(Wine::class);
-		$data = [
-			'value' => true,
-		];
-
-		$this->wineRepository->shouldReceive('update')
-			->once()
-			->with($wine, [
-				'chosen' => true,
-		]);
-
-		$this->handler->updateChosen($wine, $data);
-	}
-
-	public function testUpdateChosenValidationException() {
-		$wine = Mockery::mock(Wine::class);
-		$data = [
-			'value' => 'hello',
-		];
-
-		$this->wineRepository->shouldNotReceive('update');
-
-		$this->setExpectedException(ValidationException::class);
-		$this->handler->updateChosen($wine, $data);
-	}
-
 	public function testImportChosen() {
 		// TODO
 	}


### PR DESCRIPTION
Fixes #172 